### PR TITLE
Clean up documentation a bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.13)
 file(STRINGS "${CMAKE_SOURCE_DIR}/version.txt" projectVersion)
-project("libcosimc" VERSION ${projectVersion})
+project("libcosimc"
+    VERSION "${projectVersion}"
+    DESCRIPTION "C wrapper for the libcosim C++ library"
+)
 
 # ==============================================================================
 # Build settings
@@ -145,8 +148,6 @@ install(DIRECTORY "include/" DESTINATION "${LIBCOSIMC_HEADER_INSTALL_DIR}")
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
     message("Found Doxygen, API documentation will be built.")
-    set(DOXYGEN_PROJECT_NAME "libcosimc")
-    set(DOXYGEN_PROJECT_BRIEF "C library for distributed co-simulation")
     set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output/doc")
     set(DOXYGEN_GENERATE_LATEX "NO")
     set(DOXYGEN_RECURSIVE "YES")

--- a/include/cosim.h
+++ b/include/cosim.h
@@ -1,7 +1,6 @@
 /**
  *  \file
- *  C library header.
- *  \ingroup csecorec
+ *  Main header file
  */
 #ifndef COSIM_H
 #define COSIM_H
@@ -12,8 +11,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-
-/// \defgroup csecorec C library
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Since we don't combine the C++ and C libraries in one documentation set anymore, we no longer need the `\xxxgroup` commands.  In addition, CMake's `FindDoxygen` module now has the ability to pick up the project name and description from CMake variables set by the `project()` command.

This is part of open-simulation-platform/cse-core#300.