### PR TITLE
Use more conventional Conan channel names

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -66,6 +66,8 @@ jobs:
           - os: windows-2016
             build_type: Debug
             option_fmuproxy: 'fmuproxy=True'
+    env:
+      CONAN_USE_ALWAYS_SHORT_PATHS: True
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -67,7 +67,7 @@ jobs:
             build_type: Debug
             option_fmuproxy: 'fmuproxy=True'
     env:
-      CONAN_USE_ALWAYS_SHORT_PATHS: True
+      CONAN_USE_ALWAYS_SHORT_PATHS: 'True'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -38,9 +38,14 @@ jobs:
         run: conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/public --force
       - name: Conan create
         run: |
-          BRANCH=${GITHUB_REF#refs/*/}
-          SHORT_BRANCH=${BRANCH:0:50}
-          CHANNEL=${SHORT_BRANCH//\//_}
+          REFNAME="${GITHUB_REF#refs/*/}"
+          VERSION="v$(<version.txt)"
+          if [[ $GITHUB_REF == refs/tags/* ]] && [[ $REFNAME == $VERSION ]]; then CHANNEL="stable"
+          elif [[ $REFNAME == master ]]; then CHANNEL="testing"
+          else
+            SHORT_REFNAME="${REFNAME:0:40}"
+            CHANNEL="testing-${SHORT_REFNAME//\//_}"
+          fi
           conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_fmuproxy }} --build missing . osp/${CHANNEL}
       - name: Conan upload
         run: |
@@ -74,9 +79,14 @@ jobs:
       - name: Conan create
         shell: bash
         run: |
-          BRANCH=${GITHUB_REF#refs/*/}
-          SHORT_BRANCH=${BRANCH:0:50}
-          CHANNEL=${SHORT_BRANCH//\//_}
+          REFNAME="${GITHUB_REF#refs/*/}"
+          VERSION="v$(<version.txt)"
+          if [[ $GITHUB_REF == refs/tags/* ]] && [[ $REFNAME == $VERSION ]]; then CHANNEL="stable"
+          elif [[ $REFNAME == master ]]; then CHANNEL="testing"
+          else
+            SHORT_REFNAME="${REFNAME:0:40}"
+            CHANNEL="testing-${SHORT_REFNAME//\//_}"
+          fi
           conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -o libcosim:${{ matrix.option_fmuproxy }} . osp/${CHANNEL}
       - name: Conan upload
         run: conan upload --all -c -r osp 'libcosimc*'

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,7 @@ class LibCosimCConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "virtualrunenv"
     requires = (
-        "libcosim/0.8.0@osp/master"
+        "libcosim/0.8.0@osp/testing"
         )
 
     def set_version(self):


### PR DESCRIPTION
Accompanies open-simulation-platform/libcosim#600 to fix open-simulation-platform/libcosim#591.

It's the same change in the workflow, with an update of the channel name in `conanfile.py`.