### PR TITLE
#24 replacing conan-public with conan-local

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -35,7 +35,7 @@ jobs:
           sudo pip3 install conan
           sudo apt-get install -y doxygen
       - name: Configure Conan
-        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-public --force
+        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
       - name: Conan create
         run: |
           REFNAME="${GITHUB_REF#refs/*/}"
@@ -77,7 +77,7 @@ jobs:
           pip3 install conan
           choco install doxygen.install
       - name: Configure Conan
-        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-public --force
+        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
       - name: Conan create
         shell: bash
         run: |

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -1,7 +1,7 @@
 name: libcosimc CI Conan
 
 # This workflow is triggered on pushes to the repository.
-on: [push]
+on: [push, workflow_dispatch]
 
 env:
   CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}


### PR DESCRIPTION
Preparing to remove the virtual repository osp.jfrog.io/artifactory/conan-public

Same changes for the libcosimc workflow as for libcosim in this [PR](https://github.com/open-simulation-platform/libcosim/pull/630)

Closing #24