### PR TITLE
Renaming option to proxyfmu and build with Docker

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -3,41 +3,42 @@ name: libcosimc CI Conan
 # This workflow is triggered on pushes to the repository.
 on: [push, workflow_dispatch]
 
-env:
-  CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
-  CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
-  CONAN_REVISIONS_ENABLED: 1
-  CONAN_NON_INTERACTIVE: True
-
 jobs:
   conan-on-linux:
     name: Conan
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
         build_type: [Debug, Release]
-        compiler_version: [7]
+        compiler_version: [8, 9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 
-        exclude:
-        - os: ubuntu-18.04
-          build_type: Debug
-          option_proxyfmu: 'proxyfmu=True'
-
     steps:
       - uses: actions/checkout@v2
-      - name: Install prerequisites
+      - name: Generate Dockerfile
         run: |
-          sudo pip3 install --upgrade setuptools pip
-          sudo pip3 install conan
-          sudo apt-get install -y doxygen
-      - name: Configure Conan
-        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-      - name: Conan create
+          mkdir /tmp/osp-builder-docker
+          cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
+          FROM conanio/gcc${{ matrix.compiler_version }}
+          USER root
+          RUN apt-get update && apt-get install -y --force-yes patchelf
+          ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
+          ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
+          ENV CONAN_REVISIONS_ENABLED=1
+          ENV CONAN_NON_INTERACTIVE=1
+          ENV CONAN_USE_ALWAYS_SHORT_PATHS=1
+          COPY entrypoint.sh /
+          ENTRYPOINT /entrypoint.sh
+          EOF
+      - name: Generate entrypoint.sh
         run: |
+          cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
+          #!/bin/bash -v
+          set -eu
+          cd /mnt/source
+          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
           REFNAME="${GITHUB_REF#refs/*/}"
           VERSION="v$(<version.txt)"
           if [[ $GITHUB_REF == refs/tags/* ]] && [[ $REFNAME == $VERSION ]]; then CHANNEL="stable"
@@ -47,9 +48,15 @@ jobs:
             CHANNEL="testing-${SHORT_REFNAME//\//_}"
           fi
           conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} --build missing . osp/${CHANNEL}
-      - name: Conan upload
-        run: |
           conan upload --all -c -r osp 'libcosimc*'
+          EOF
+          chmod 0755 /tmp/osp-builder-docker/entrypoint.sh
+      - name: Build Docker image
+        run: |
+          docker build -t osp-builder /tmp/osp-builder-docker/
+      - name: Build libcosimc
+        run: |
+          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source:ro osp-builder
 
   conan-on-windows:
     name: Conan
@@ -61,13 +68,12 @@ jobs:
         build_type: [Debug, Release]
         compiler_version: [15]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
-
-        exclude:
-          - os: windows-2016
-            build_type: Debug
-            option_proxyfmu: 'proxyfmu=True'
     env:
-      CONAN_USE_ALWAYS_SHORT_PATHS: 'True'
+      CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
+      CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
+      CONAN_REVISIONS_ENABLED: 1
+      CONAN_NON_INTERACTIVE: 1
+      CONAN_USE_ALWAYS_SHORT_PATHS: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -20,12 +20,12 @@ jobs:
         build_type: [Debug, Release]
         compiler_version: [7]
         compiler_libcxx: [libstdc++11]
-        option_fmuproxy: ['fmuproxy=True', 'fmuproxy=False']
+        option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 
         exclude:
         - os: ubuntu-18.04
           build_type: Debug
-          option_fmuproxy: 'fmuproxy=True'
+          option_proxyfmu: 'proxyfmu=True'
 
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
             SHORT_REFNAME="${REFNAME:0:40}"
             CHANNEL="testing-${SHORT_REFNAME//\//_}"
           fi
-          conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_fmuproxy }} --build missing . osp/${CHANNEL}
+          conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o libcosim:${{ matrix.option_proxyfmu }} --build missing . osp/${CHANNEL}
       - name: Conan upload
         run: |
           conan upload --all -c -r osp 'libcosimc*'
@@ -60,12 +60,12 @@ jobs:
         os: [windows-2016]
         build_type: [Debug, Release]
         compiler_version: [15]
-        option_fmuproxy: ['fmuproxy=True', 'fmuproxy=False']
+        option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 
         exclude:
           - os: windows-2016
             build_type: Debug
-            option_fmuproxy: 'fmuproxy=True'
+            option_proxyfmu: 'proxyfmu=True'
     env:
       CONAN_USE_ALWAYS_SHORT_PATHS: 'True'
 
@@ -89,6 +89,6 @@ jobs:
             SHORT_REFNAME="${REFNAME:0:40}"
             CHANNEL="testing-${SHORT_REFNAME//\//_}"
           fi
-          conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -o libcosim:${{ matrix.option_fmuproxy }} . osp/${CHANNEL}
+          conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -o libcosim:${{ matrix.option_proxyfmu }} . osp/${CHANNEL}
       - name: Conan upload
         run: conan upload --all -c -r osp 'libcosimc*'

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -23,7 +23,7 @@ jobs:
           cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
           FROM conanio/gcc${{ matrix.compiler_version }}
           USER root
-          RUN apt-get update && apt-get install -y --force-yes patchelf
+          RUN apt-get update && apt-get install -y --force-yes doxygen
           ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
           ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
           ENV CONAN_REVISIONS_ENABLED=1

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [8, 9]
+        compiler_version: [7, 8, 9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project("libcosimc"
     DESCRIPTION "C wrapper for the libcosim C++ library"
 )
 
+# To enable verbose when needed
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
 # ==============================================================================
 # Build settings
 # ==============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project("libcosimc"
 )
 
 # To enable verbose when needed
-set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_VERBOSE_MAKEFILE OFF)
 
 # ==============================================================================
 # Build settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,12 @@ add_library(cosimc "include/cosim.h" "src/cosim.cpp" ${generatedSourcesFull})
 
 target_compile_features(cosimc PRIVATE "cxx_std_17")
 target_include_directories(cosimc PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>")
-target_link_libraries(cosimc PUBLIC libcosim::cosim)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(cosimc PUBLIC libcosim::cosim stdc++)
+else()
+    target_link_libraries(cosimc PUBLIC libcosim::cosim)
+endif()
+
 if(WIN32 AND NOT BUILD_SHARED_LIBS)
     set_target_properties(cosimc PROPERTIES OUTPUT_NAME "libcosimc")
 endif()

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ How to build
 
 `libcosimc` can be built in the same way as libcosim with the following differences in [step 2]
 
-To include FMU-proxy support use `-o libcosim:'fmuproxy=True'` when installing dependencies in 
+To include FMU-proxy support use `-o libcosim:'proxyfmu=True'` when installing dependencies in 
      
-     conan install ..  -o libcosim:'fmuproxy=True' --build=missing
+     conan install ..  -o libcosim:'proxyfmu=True' --build=missing
      
 When running cmake use `-DLIBCOSIMC_USING_CONAN=TRUE`
  

--- a/tests/execution_from_ssp_custom_algo_test.c
+++ b/tests/execution_from_ssp_custom_algo_test.c
@@ -67,7 +67,7 @@ int main()
     rc = cosim_execution_get_slave_infos(execution, &infos[0], numSlaves);
     if (rc < 0) { goto Lerror; }
 
-    char name[17];
+    char name[SLAVE_NAME_MAX_SIZE];
     strcpy(name, "KnuckleBoomCrane");
     for (size_t i = 0; i < numSlaves; i++) {
         if (0 == strncmp(infos[i].name, name, SLAVE_NAME_MAX_SIZE)) {

--- a/tests/execution_from_ssp_custom_algo_test.c
+++ b/tests/execution_from_ssp_custom_algo_test.c
@@ -70,7 +70,7 @@ int main()
     char name[SLAVE_NAME_MAX_SIZE];
     strcpy(name, "KnuckleBoomCrane");
     for (size_t i = 0; i < numSlaves; i++) {
-        if (0 == strncmp(infos[i].name, name, SLAVE_NAME_MAX_SIZE)) {
+        if (0 == strncmp(infos[i].name, name, 15)) {
             double value = -1;
             cosim_slave_index slaveIndex = infos[i].index;
             cosim_value_reference varIndex = 2;

--- a/tests/execution_from_ssp_custom_algo_test.c
+++ b/tests/execution_from_ssp_custom_algo_test.c
@@ -67,7 +67,8 @@ int main()
     rc = cosim_execution_get_slave_infos(execution, &infos[0], numSlaves);
     if (rc < 0) { goto Lerror; }
 
-    const char name[] = "KnuckleBoomCrane";
+    char name[17];
+    strcpy(name, "KnuckleBoomCrane");
     for (size_t i = 0; i < numSlaves; i++) {
         if (0 == strncmp(infos[i].name, name, SLAVE_NAME_MAX_SIZE)) {
             double value = -1;

--- a/tests/execution_from_ssp_custom_algo_test.c
+++ b/tests/execution_from_ssp_custom_algo_test.c
@@ -67,8 +67,9 @@ int main()
     rc = cosim_execution_get_slave_infos(execution, &infos[0], numSlaves);
     if (rc < 0) { goto Lerror; }
 
+    const char name[] = "KnuckleBoomCrane";
     for (size_t i = 0; i < numSlaves; i++) {
-        if (0 == strncmp(infos[i].name, "KnuckleBoomCrane", SLAVE_NAME_MAX_SIZE)) {
+        if (0 == strncmp(infos[i].name, name, SLAVE_NAME_MAX_SIZE)) {
             double value = -1;
             cosim_slave_index slaveIndex = infos[i].index;
             cosim_value_reference varIndex = 2;

--- a/tests/execution_from_ssp_custom_algo_test.c
+++ b/tests/execution_from_ssp_custom_algo_test.c
@@ -70,7 +70,9 @@ int main()
     char name[SLAVE_NAME_MAX_SIZE];
     strcpy(name, "KnuckleBoomCrane");
     for (size_t i = 0; i < numSlaves; i++) {
-        if (0 == strncmp(infos[i].name, name, 15)) {
+        char a[SLAVE_NAME_MAX_SIZE];
+        strcpy(a, infos[i].name);
+        if (0 == strncmp(a, name, SLAVE_NAME_MAX_SIZE)) {
             double value = -1;
             cosim_slave_index slaveIndex = infos[i].index;
             cosim_value_reference varIndex = 2;

--- a/tests/execution_from_ssp_custom_algo_test.c
+++ b/tests/execution_from_ssp_custom_algo_test.c
@@ -68,11 +68,9 @@ int main()
     if (rc < 0) { goto Lerror; }
 
     char name[SLAVE_NAME_MAX_SIZE];
-    strcpy(name, "KnuckleBoomCrane");
     for (size_t i = 0; i < numSlaves; i++) {
-        char a[SLAVE_NAME_MAX_SIZE];
-        strcpy(a, infos[i].name);
-        if (0 == strncmp(a, name, SLAVE_NAME_MAX_SIZE)) {
+        strcpy(name, infos[i].name);
+        if (0 == strncmp(name, "KnuckleBoomCrane", SLAVE_NAME_MAX_SIZE)) {
             double value = -1;
             cosim_slave_index slaveIndex = infos[i].index;
             cosim_value_reference varIndex = 2;

--- a/tests/execution_from_ssp_test.c
+++ b/tests/execution_from_ssp_test.c
@@ -58,8 +58,10 @@ int main()
     rc = cosim_execution_get_slave_infos(execution, &infos[0], numSlaves);
     if (rc < 0) { goto Lerror; }
 
+    char name[SLAVE_NAME_MAX_SIZE];
     for (size_t i = 0; i < numSlaves; i++) {
-        if (0 == strncmp(infos[i].name, "KnuckleBoomCrane", SLAVE_NAME_MAX_SIZE)) {
+        strcpy(name, infos[i].name);
+        if (0 == strncmp(name, "KnuckleBoomCrane", SLAVE_NAME_MAX_SIZE)) {
             double value = -1;
             cosim_slave_index slaveIndex = infos[i].index;
             cosim_value_reference varIndex = 2;


### PR DESCRIPTION
- Using renamed option proxyfmu
- Build with Docker containers
	- Linking with `stdc++` to make gcc8 build with `proxyfmu=True`
	- Small modification to a couple of tests to avoid stringop-overflow warning with gcc9
