### PR TITLE
Resolve zlib conflict

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,9 @@ class LibCosimCConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "virtualrunenv"
     requires = (
-        "libcosim/0.9.0@osp/stable"
+        "libcosim/0.9.0@osp/stable",
+        # conflict resolution
+        "zlib/1.2.12"
         )
 
     def set_version(self):


### PR DESCRIPTION
Temporarily fixing zlib conflict for libcosimc v0.9.0 release

Resolves
```
ERROR: Conflict in libzip/1.7.3:
    'libzip/1.7.3' requires 'zlib/1.2.11' while 'boost/1.71.0' requires 'zlib/1.2.12'.
    To fix this conflict you need to override the package 'zlib' in your root package.
```