### PR TITLE
Update after libcosim release

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [7, 8, 9]
+        compiler_version: [9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ option(LIBCOSIMC_USING_CONAN "Whether Conan is used for package management" OFF)
 
 # Our custom CMake scripts go in the cmake/ subdirectory.
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 # Use a common output directory for all targets.
 # The main purpose of this is to ensure that the DLLs and test executables
@@ -140,10 +142,9 @@ add_library(cosimc "include/cosim.h" "src/cosim.cpp" ${generatedSourcesFull})
 
 target_compile_features(cosimc PRIVATE "cxx_std_17")
 target_include_directories(cosimc PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>")
+target_link_libraries(cosimc PUBLIC libcosim::libcosim Boost::fiber)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries(cosimc PUBLIC libcosim::cosim stdc++ Boost::fiber)
-else()
-    target_link_libraries(cosimc PUBLIC libcosim::cosim Boost::fiber)
+    target_link_libraries(cosimc PUBLIC stdc++)
 endif()
 
 if(WIN32 AND NOT BUILD_SHARED_LIBS)

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class LibCosimCConan(ConanFile):
         "revision": "auto"
     }
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "virtualrunenv"
+    generators = "cmake", "cmake_find_package", "virtualrunenv"
     requires = (
         "libcosim/0.10.0@osp/stable"
         )

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,7 @@ class LibCosimCConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "virtualrunenv"
     requires = (
-        "libcosim/0.10.0@osp/testing"
+        "libcosim/0.10.0@osp/stable"
         )
 
     def set_version(self):


### PR DESCRIPTION
Updating to 0.10.0/stable after libcosim release. Or should we go to 0.11.0/testing?

Also removed GCC 7&8 from the build matrix here as well - shout if you disagree :) 

@markaren the builds with proxyfmu=ON are all failing on GCC9 with the same error message - any ideas?

> CMake Error at C:/Program Files/CMake/share/cmake-3.25/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
>   By not providing "FindThrift.cmake" in CMAKE_MODULE_PATH this project has
>   asked CMake to find a package configuration file provided by "Thrift", but
> -- Configuring incomplete, errors occurred!
> See also "C:/.conan/f67648/1/CMakeFiles/CMakeOutput.log".
>   CMake did not find one.
> See also "C:/.conan/f67648/1/CMakeFiles/CMakeError.log".
> 
>   Could not find a package configuration file provided by "Thrift" with any
>   of the following names:
> 
>     ThriftConfig.cmake
>     thrift-config.cmake
> 
>   Add the installation prefix of "Thrift" to CMAKE_PREFIX_PATH or set
>   "Thrift_DIR" to a directory containing one of the above files.  If "Thrift"
>   provides a separate development package or SDK, be sure it has been
>   installed.
> 