### PR TITLE
scm.url to `auto`

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class LibCosimCConan(ConanFile):
     exports = "version.txt"
     scm = {
         "type": "git",
-        "url": "git@github.com:open-simulation-platform/libcosimc.git",
+        "url": "auto",
         "revision": "auto"
     }
     settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
This is a quick fix for libraries using libcosimc failing build due to not having a read access to "git@github.com:open-simulation-platform/libcosimc.git"

`scm` is deprecated in conan v2 so will be removed anyways.