### PR TITLE
Use static libcosim in CI build

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -46,6 +46,7 @@ jobs:
           conan create \
             --settings="build_type=${{ matrix.build_type }}" \
             --options="libcosimc/*:${{ matrix.option_shared }}" \
+            --options="libcosim/*:shared=False" \
             --options="libcosim/*:${{ matrix.option_proxyfmu }}" \
             --build=missing \
             --user=osp \
@@ -98,6 +99,7 @@ jobs:
           conan create \
             --settings="build_type=${{ matrix.build_type }}" \
             --options="libcosimc*:${{ matrix.option_shared }}" \
+            --options="libcosim/*:shared=False" \
             --options="libcosim/*:${{ matrix.option_proxyfmu }}" \
             --build=missing \
             --user=osp \

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,7 +37,6 @@ class LibCosimCConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        self.options["*"].shared = self.options.shared
 
     # Dependencies/requirements
     tool_requires = (


### PR DESCRIPTION
This PR contains two minor but related changes:
1. Removal of the line `self.options["*"].shared = self.options.shared` from `conanfile.py`:
This is necessary to be able to build a **shared library** of libcosimc with a **static build** of libcosim. This is desirable because it would mean that the libcosim library does not depend on other shared libraries which reduce the chances of compatibility issues with any FMU dependencies.
2. CI builds and Conan publishing now specify a static build of libcosim because this is presumably the most common use case both when libcosimc is built as a static and as a shared library. Alternatively the libcosim shared option could be included in the build matrix, but this increase CI build times significantly due to the number of jobs.

A note about changing the behaviour of the Conan `shared` option: A quick survey of packages at Conan Center indicate that setting the `shared` option for all dependencies in `conanfile.py` (which this PR propose to remove) is not common. For example [nas](https://github.com/conan-io/conan-center-index/blob/be4bb64cdd8570b8a39e01bca8b17deeb276f909/recipes/nas/all/conanfile.py#L34) depend on [flex](https://github.com/conan-io/conan-center-index/blob/be4bb64cdd8570b8a39e01bca8b17deeb276f909/recipes/flex/all/conanfile.py#L23), but the `configure` method in nas does not set the `shared` option for flex.