### PR TITLE
Only run doxygen if it can be found in path

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y pipx doxygen
-          pipx install conan cmake
+          pipx install conan
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Configure Conan
         run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout
@@ -61,7 +62,8 @@ class LibCosimCConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
-        cmake.build(target="doc")
+        if shutil.which("doxygen"):
+            cmake.build(target="doc")
         if self._is_tests_enabled():
             env = VirtualRunEnv(self).environment()
             env.define("CTEST_OUTPUT_ON_FAILURE", "ON")
@@ -72,7 +74,8 @@ class LibCosimCConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        cmake.build(target="install-doc")
+        if shutil.which("doxygen"):
+            cmake.build(target="install-doc")
 
     def package_info(self):
         self.cpp_info.libs = [ "cosimc" ]

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,6 @@ class LibCosimCConan(ConanFile):
     # Dependencies/requirements
     tool_requires = (
         "cmake/[>=4.0]",
-        "doxygen/1.17.0",
     )
     requires = (
         "libcosim/0.11.2@osp/stable",
@@ -63,7 +62,8 @@ class LibCosimCConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
-        cmake.build(target="doc")
+        if shutil.which("doxygen"):
+            cmake.build(target="doc")
 
         if self._is_tests_enabled():
             env = VirtualRunEnv(self).environment()
@@ -75,7 +75,8 @@ class LibCosimCConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        cmake.build(target="install-doc")
+        if shutil.which("doxygen"):
+            cmake.build(target="install-doc")
 
     def package_info(self):
         self.cpp_info.libs = [ "cosimc" ]

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,6 +43,7 @@ class LibCosimCConan(ConanFile):
     # Dependencies/requirements
     tool_requires = (
         "cmake/[>=4.0]",
+        "doxygen/1.17.0",
     )
     requires = (
         "libcosim/0.11.2@osp/stable",
@@ -62,8 +63,8 @@ class LibCosimCConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
-        if shutil.which("doxygen"):
-            cmake.build(target="doc")
+        cmake.build(target="doc")
+
         if self._is_tests_enabled():
             env = VirtualRunEnv(self).environment()
             env.define("CTEST_OUTPUT_ON_FAILURE", "ON")
@@ -74,8 +75,7 @@ class LibCosimCConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        if shutil.which("doxygen"):
-            cmake.build(target="install-doc")
+        cmake.build(target="install-doc")
 
     def package_info(self):
         self.cpp_info.libs = [ "cosimc" ]


### PR DESCRIPTION
In previous PR, doxygen was removed in tool_requires because it currently only supports `cppstd < 20` and `cmake<4` (i.e. fails to build when these requirements are not met on a build machine).

This PR only triggers `doxygen` when the binary is found.